### PR TITLE
CI: don't pin Biome version so it gets pulled from deps

### DIFF
--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
       - name: Setup Biome
         uses: biomejs/setup-biome@454fa0d884737805f48d7dc236c1761a0ac3cc13 # v2.6.0
         with:


### PR DESCRIPTION
> Automatic version detection
> To automatically determine the Biome version to install, simply omit the version input.
> The action first looks for the version of the @biomejs/biome dependency in the lockfiles of popular package managers (npm, yarn, pnpm, bun). If no version can be determined from lockfiles, it will next check package.json. If neither lockfiles nor package.json provide a version, the action will then look for a declared version in the project's Biome configuration file (it extracts the version from the $schema field). If no version is found after these checks, the action installs the latest version of the Biome CLI.