### PR TITLE
CI: don't pin Biome version so it gets pulled from deps

### DIFF
--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -17,7 +17,5 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Biome
         uses: biomejs/setup-biome@29711cbb52afee00eb13aeb30636592f9edc0088 # v2.7.0
-        with:
-          version: latest
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
Actually doing what #7 was supposed to do.