### PR TITLE
Fix layout overflow issues with flexbox and viewport height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated files
 .astro/
+.wrangler/
 dist/
 
 node_modules/

--- a/src/components/ArtboardEditor.tsx
+++ b/src/components/ArtboardEditor.tsx
@@ -25,7 +25,8 @@ export default function ArtboardEditor({
     <div
       style={{
         position: "relative",
-        height: "100%",
+        flex: 1,
+        minHeight: 0,
         width: "100%",
       }}
     >

--- a/src/components/ArtboardRenderer.tsx
+++ b/src/components/ArtboardRenderer.tsx
@@ -20,7 +20,7 @@ export default function ArtboardRenderer({
       ref={canvasRef}
       style={{
         width: "100%",
-        height: "100vh",
+        height: "100%",
         display: "flex",
         overflow: "auto",
         position: "relative",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,9 +10,17 @@
   transition: none;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
   background: var(--bg);
   color: var(--text);
+  display: flex;
+  flex-direction: column;
 }


### PR DESCRIPTION
## Summary
This PR fixes layout overflow issues by restructuring the root layout to use flexbox and properly constraining viewport heights. The changes ensure that the application layout respects viewport boundaries without unwanted scrolling.

## Key Changes
- **Global styles**: Added `height: 100%` and `overflow: hidden` to `html` and `body` elements to constrain the viewport
- **Body layout**: Changed body to use `display: flex` with `flex-direction: column` to enable proper flex-based layout for child components
- **ArtboardEditor**: Replaced fixed `height: 100%` with `flex: 1` and added `minHeight: 0` to allow the editor to grow/shrink with available space while preventing content overflow
- **ArtboardRenderer**: Changed canvas height from `100vh` (full viewport height) to `100%` (parent container height) for proper responsive sizing
- **Build config**: Added `.wrangler/` to `.gitignore` to exclude Wrangler build artifacts

## Implementation Details
The key insight is using `flex: 1` with `minHeight: 0` on the ArtboardEditor to allow it to fill available space while respecting flex constraints. The `minHeight: 0` override is necessary because flex items have an implicit `min-height: auto` that can prevent proper shrinking. By changing the canvas from `100vh` to `100%`, it now respects its parent container's dimensions rather than always being full viewport height.

https://claude.ai/code/session_01QttsutZntTGuPWD6DzfL6P