### PR TITLE
Add element dragging and text tool support to artboard

### DIFF
--- a/src/components/ArtboardEditor.tsx
+++ b/src/components/ArtboardEditor.tsx
@@ -1,5 +1,5 @@
 import type { ArtboardDocument, TextElement } from "@dotforge/core";
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import PropertiesPanel from "../components/layout/PropertiesPanel";
 import ShapesToolbar, { type Tool } from "../components/layout/ShapesToolbar";
 import ArtboardRenderer from "./ArtboardRenderer";
@@ -28,6 +28,34 @@ export default function ArtboardEditor({
     el.y = y;
     forceUpdate();
   }
+
+  function handleDeleteElement(el: TextElement) {
+    const idx = artboard.elements.indexOf(el);
+    if (idx === -1) return;
+    artboard.elements.splice(idx, 1);
+    setSelected((current) => (current === el ? null : current));
+    forceUpdate();
+  }
+
+  useEffect(() => {
+    if (!selected) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      if (selected) handleDeleteElement(selected);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selected]);
 
   function handleAddTextElement(x: number, y: number) {
     const newEl: TextElement = {
@@ -70,7 +98,11 @@ export default function ArtboardEditor({
 
       <ShapesToolbar activeTool={activeTool} onSelectTool={setActiveTool} />
 
-      <PropertiesPanel element={selected} onChange={forceUpdate} />
+      <PropertiesPanel
+        element={selected}
+        onChange={forceUpdate}
+        onDelete={() => selected && handleDeleteElement(selected)}
+      />
     </div>
   );
 }

--- a/src/components/ArtboardEditor.tsx
+++ b/src/components/ArtboardEditor.tsx
@@ -23,6 +23,26 @@ export default function ArtboardEditor({
     setRevision((r) => r + 1);
   }
 
+  function handleMoveElement(el: TextElement, x: number, y: number) {
+    el.x = x;
+    el.y = y;
+    forceUpdate();
+  }
+
+  function handleAddTextElement(x: number, y: number) {
+    const newEl: TextElement = {
+      type: "text",
+      x,
+      y,
+      text: "Text",
+      fontSize: 3,
+    };
+    artboard.elements.push(newEl);
+    setSelected(newEl);
+    setActiveTool("select");
+    forceUpdate();
+  }
+
   const sizedArtboard = { ...artboard, width, height };
 
   return (
@@ -43,6 +63,9 @@ export default function ArtboardEditor({
           setWidth(w);
           setHeight(h);
         }}
+        onMoveElement={handleMoveElement}
+        onAddTextElement={handleAddTextElement}
+        activeTool={activeTool}
       />
 
       <ShapesToolbar activeTool={activeTool} onSelectTool={setActiveTool} />

--- a/src/components/ArtboardRenderer.tsx
+++ b/src/components/ArtboardRenderer.tsx
@@ -1,19 +1,103 @@
-import type { ArtboardDocument, TextElement } from "@dotforge/core";
+import type { TextElement } from "@dotforge/core";
 import { useRef } from "preact/hooks";
+import type { Tool } from "./layout/ShapesToolbar";
+
+const DRAG_THRESHOLD_PX = 3;
 
 export default function ArtboardRenderer({
   artboard,
   selected,
   onSelect,
   onResize,
+  onMoveElement,
+  onAddTextElement,
+  activeTool,
 }: {
-  artboard: ArtboardDocument;
+  artboard: import("@dotforge/core").ArtboardDocument;
   selected: TextElement | null;
   onSelect: (el: TextElement | null) => void;
   revision: number;
   onResize?: (width: number, height: number) => void;
+  onMoveElement: (el: TextElement, x: number, y: number) => void;
+  onAddTextElement: (x: number, y: number) => void;
+  activeTool: Tool;
 }) {
   const canvasRef = useRef<HTMLDivElement | null>(null);
+  const paperRef = useRef<HTMLDivElement | null>(null);
+
+  function pxToMm(px: number) {
+    const paper = paperRef.current;
+    if (!paper) return px;
+    const rect = paper.getBoundingClientRect();
+    if (rect.width === 0) return px;
+    return (px / rect.width) * artboard.width;
+  }
+
+  function clientToMm(clientX: number, clientY: number) {
+    const paper = paperRef.current;
+    if (!paper) return { x: 0, y: 0 };
+    const rect = paper.getBoundingClientRect();
+    const scaleX = rect.width === 0 ? 1 : artboard.width / rect.width;
+    const scaleY = rect.height === 0 ? 1 : artboard.height / rect.height;
+    return {
+      x: (clientX - rect.left) * scaleX,
+      y: (clientY - rect.top) * scaleY,
+    };
+  }
+
+  function handleElementPointerDown(e: PointerEvent, el: TextElement) {
+    if (activeTool !== "select") return;
+    e.stopPropagation();
+    const target = e.currentTarget as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+
+    const startClientX = e.clientX;
+    const startClientY = e.clientY;
+    const startX = el.x;
+    const startY = el.y;
+    let dragging = false;
+
+    const handleMove = (ev: PointerEvent) => {
+      const dx = ev.clientX - startClientX;
+      const dy = ev.clientY - startClientY;
+      if (!dragging && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) {
+        return;
+      }
+      if (!dragging) {
+        dragging = true;
+        onSelect(el);
+      }
+      const nextX = startX + pxToMm(dx);
+      const nextY = startY + pxToMm(dy);
+      const clampedX = Math.max(0, Math.min(artboard.width, nextX));
+      const clampedY = Math.max(0, Math.min(artboard.height, nextY));
+      onMoveElement(el, clampedX, clampedY);
+    };
+
+    const handleUp = (ev: PointerEvent) => {
+      target.releasePointerCapture?.(ev.pointerId);
+      target.removeEventListener("pointermove", handleMove);
+      target.removeEventListener("pointerup", handleUp);
+      target.removeEventListener("pointercancel", handleUp);
+      if (!dragging) {
+        onSelect(el);
+      }
+    };
+
+    target.addEventListener("pointermove", handleMove);
+    target.addEventListener("pointerup", handleUp);
+    target.addEventListener("pointercancel", handleUp);
+  }
+
+  function handlePaperClick(e: MouseEvent) {
+    if (e.target !== e.currentTarget) return;
+    if (activeTool === "text") {
+      const { x, y } = clientToMm(e.clientX, e.clientY);
+      onAddTextElement(x, y);
+      return;
+    }
+    onSelect(null);
+  }
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: Canvas uses pointer-based interaction; keyboard selection is not applicable for this visual editor.
@@ -42,6 +126,7 @@ export default function ArtboardRenderer({
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: Artboard paper uses pointer-based interaction for visual editing. */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: Artboard paper uses pointer-based interaction for visual editing. */}
         <div
+          ref={paperRef}
           style={{
             position: "relative",
             background: "white",
@@ -54,35 +139,36 @@ export default function ArtboardRenderer({
             alignItems: "flex-start",
             justifyContent: "flex-start",
             boxSizing: "border-box",
+            cursor: activeTool === "text" ? "crosshair" : "default",
           }}
-          onClick={(e) => {
-            // Clicking empty artboard area
-            if (e.target === e.currentTarget) onSelect(null);
-          }}
+          onClick={handlePaperClick}
         >
           {artboard.elements.map((el) => (
             // biome-ignore lint/a11y/useKeyWithClickEvents: Artboard elements use pointer-based drag/click interaction for visual editing.
             // biome-ignore lint/a11y/noStaticElementInteractions: Artboard elements use pointer-based drag/click interaction for visual editing.
             <div
               key={el.id}
+              onPointerDown={(e) =>
+                handleElementPointerDown(e as unknown as PointerEvent, el)
+              }
               onClick={(e) => {
                 e.stopPropagation();
-                onSelect(el);
               }}
               style={{
                 position: "absolute",
-                left: el.x,
-                top: el.y,
+                left: `${el.x}mm`,
+                top: `${el.y}mm`,
                 padding: "1px 2px",
                 color: "black",
                 background:
                   selected === el ? "rgba(0,0,255,0.1)" : "transparent",
                 border:
                   selected === el ? "1px solid rgba(0,0,255,0.4)" : "none",
-                cursor: "pointer",
+                cursor: activeTool === "select" ? "move" : "default",
                 fontSize: `${el.fontSize}mm`,
                 fontFamily: "sans-serif",
                 userSelect: "none",
+                touchAction: "none",
               }}
             >
               {el.text}

--- a/src/components/layout/PropertiesPanel.tsx
+++ b/src/components/layout/PropertiesPanel.tsx
@@ -4,9 +4,11 @@ import type { JSX } from "preact";
 export default function PropertiesPanel({
   element,
   onChange,
+  onDelete,
 }: {
   element: TextElement | null;
   onChange: () => void;
+  onDelete: () => void;
 }) {
   if (!element) return null;
 
@@ -66,6 +68,24 @@ export default function PropertiesPanel({
           }}
         />
       </label>
+
+      <button
+        type="button"
+        onClick={onDelete}
+        style={{
+          marginTop: "6px",
+          width: "100%",
+          padding: "6px 10px",
+          background: "var(--danger, #c0392b)",
+          color: "white",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+          fontSize: "13px",
+        }}
+      >
+        Delete
+      </button>
     </div>
   );
 }

--- a/src/components/layout/PropertiesPanel.tsx
+++ b/src/components/layout/PropertiesPanel.tsx
@@ -57,9 +57,13 @@ export default function PropertiesPanel({
         <br />
         <input
           type="number"
+          min={0.1}
+          step={0.1}
           value={element.fontSize}
           onInput={(e: JSX.TargetedEvent<HTMLInputElement>) => {
-            element.fontSize = Number(e.currentTarget.value);
+            const next = Number(e.currentTarget.value);
+            if (!Number.isFinite(next) || next <= 0) return;
+            element.fontSize = next;
             onChange();
           }}
           style={{


### PR DESCRIPTION
## Summary
This PR adds interactive element manipulation to the artboard editor, enabling users to drag text elements to reposition them and use a text tool to create new text elements at specific coordinates.

## Key Changes
- **Element dragging**: Implemented pointer-based drag handling for text elements with a 3px drag threshold to distinguish clicks from drags
- **Text tool support**: Added ability to click on the artboard with the text tool active to create new text elements at the clicked position
- **Coordinate system improvements**: 
  - Added `pxToMm()` and `clientToMm()` helper functions to properly convert between pixel and millimeter coordinates
  - Fixed element positioning to use millimeter units (`${el.x}mm`) instead of raw pixel values
- **Tool-aware interactions**: 
  - Cursor changes based on active tool (crosshair for text tool, move for select tool)
  - Element interactions only work when the select tool is active
- **Pointer capture**: Implemented proper pointer capture and event cleanup for drag operations
- **Boundary clamping**: Elements are constrained within artboard bounds during dragging

## Implementation Details
- Added `DRAG_THRESHOLD_PX` constant to prevent accidental drags on click
- Used `setPointerCapture()` for reliable drag tracking across the entire viewport
- Properly scaled client coordinates to artboard millimeter space accounting for zoom/scale
- Added `touchAction: "none"` to prevent browser default touch behaviors during drag
- Integrated new handlers (`onMoveElement`, `onAddTextElement`) into `ArtboardEditor` component

https://claude.ai/code/session_01MTnUM5XsjcB63qm86H4ygA