### PR TITLE
Increase neon theme contrast with starker colors

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -4,7 +4,7 @@ export const themeColors: Record<ThemeId, string> = {
   light: "#f6f8fa",
   dark: "#161b22",
   solarized: "#eee8d5",
-  neon: "#24283b",
+  neon: "#0a0e27",
 };
 
 export const themes = [

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -4,7 +4,7 @@ export const themeColors: Record<ThemeId, string> = {
   light: "#f6f8fa",
   dark: "#161b22",
   solarized: "#eee8d5",
-  neon: "#0a0e27",
+  neon: "#1a1f3a",
 };
 
 export const themes = [

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -43,13 +43,13 @@ html.theme-solarized {
 
 html.theme-neon {
   color-scheme: dark;
-  --bg: #1a1b26;
-  --panel: #24283b;
-  --panel-border: #565f89;
-  --button-bg: #2f334d;
-  --button-border: #565f89;
-  --button-hover: #414868;
-  --icon: #c0caf5;
-  --icon-hover: #ff79c6;
-  --text: #f8f8f2;
+  --bg: #0a0e27;
+  --panel: #1a1f3a;
+  --panel-border: #7b82d1;
+  --button-bg: #1a1f3a;
+  --button-border: #7b82d1;
+  --button-hover: #2d334d;
+  --icon: #f0f0f0;
+  --icon-hover: #ff00ff;
+  --text: #ffffff;
 }


### PR DESCRIPTION
- Darken background from #1a1b26 to #0a0e27 for deeper contrast
- Brighten text to pure white (#ffffff) from #f8f8f2
- Use brighter purple borders (#7b82d1) instead of #565f89
- Change icon hover to vivid magenta (#ff00ff) from pink
- Lighten icon color to #f0f0f0 from #c0caf5
- Update theme color in metadata to match new background