### PR TITLE
Fix mobile UI scaling and floating-button overlap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,10 +5,10 @@ import cloudflare from "@astrojs/cloudflare";
 import preact from "@astrojs/preact";
 import { defineConfig } from "astro/config";
 
-// Get Git commit hash at build time
+// Get the short Git commit hash at build time
 const getGitCommitHash = () => {
   try {
-    return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+    return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
   } catch (_error) {
     return "unknown";
   }

--- a/src/components/ArtboardEditor.tsx
+++ b/src/components/ArtboardEditor.tsx
@@ -115,14 +115,10 @@ export default function ArtboardEditor({
       />
 
       <div
+        class="df-float-top-center"
         style={{
-          position: "absolute",
-          top: "20px",
-          left: "50%",
-          transform: "translateX(-50%)",
           display: "flex",
           gap: "12px",
-          zIndex: 1000,
         }}
       >
         <ShapesToolbar activeTool={activeTool} onSelectTool={setActiveTool} />

--- a/src/components/layout/MainMenu.tsx
+++ b/src/components/layout/MainMenu.tsx
@@ -3,17 +3,14 @@ import ThemeButton from "../ThemeButton";
 export default function MainMenu() {
   return (
     <div
+      class="df-float-right"
       style={{
-        position: "absolute",
-        top: "20px",
-        right: "20px",
         background: "var(--panel)",
         border: "1px solid var(--panel-border)",
         borderRadius: "10px",
         padding: "8px 12px",
         display: "flex",
         gap: "12px",
-        zIndex: 1000,
         boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
       }}
     >

--- a/src/components/layout/ModuleSwitcher.tsx
+++ b/src/components/layout/ModuleSwitcher.tsx
@@ -20,17 +20,14 @@ export default function ModuleSwitcher({
 }) {
   return (
     <div
+      class="df-float-left"
       style={{
-        position: "absolute",
-        top: "20px",
-        left: "20px",
         background: "var(--panel)",
         border: "1px solid var(--panel-border)",
         borderRadius: "10px",
         padding: "8px 12px",
         display: "flex",
         gap: "12px",
-        zIndex: 1000,
         boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
       }}
     >

--- a/src/components/layout/PropertiesPanel.tsx
+++ b/src/components/layout/PropertiesPanel.tsx
@@ -14,21 +14,15 @@ export default function PropertiesPanel({
 
   return (
     <div
+      class="df-props-panel"
       style={{
-        position: "fixed",
-        top: "50%",
-        left: "16px",
-        transform: "translateY(-50%)",
         background: "var(--panel)",
         color: "var(--text)",
         border: "1px solid var(--panel-border)",
         padding: "12px 14px",
-        borderRadius: "8px",
         fontFamily: "sans-serif",
         fontSize: "13px",
-        zIndex: 9999,
         boxShadow: "0 4px 12px rgba(0,0,0,0.35)",
-        width: "204px",
       }}
     >
       <div style={{ marginBottom: "10px", fontWeight: 600 }}>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ const themeColorsJson = JSON.stringify(themeColors);
 <html lang="en" class="no-transition">
     <head>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content={themeColors.light} />
         <title>{pageTitle || "DotForge"}</title>
         <script is:inline define:vars={{ themeColorsJson }}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,3 +24,67 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+/* Floating UI groups — positioning lives here so media queries can override
+   the components' inline visual styles. */
+.df-float-left {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1000;
+}
+.df-float-right {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+.df-float-top-center {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+}
+.df-props-panel {
+  position: fixed;
+  top: 50%;
+  left: 16px;
+  transform: translateY(-50%);
+  width: 204px;
+  border-radius: 8px;
+  z-index: 9999;
+}
+
+@media (max-width: 640px) {
+  .df-float-left {
+    top: 8px;
+    left: 8px;
+  }
+  .df-float-right {
+    top: 8px;
+    right: 8px;
+  }
+
+  /* Center tool toolbar → full-width bottom bar, wraps if needed */
+  .df-float-top-center {
+    top: auto;
+    bottom: 8px;
+    left: 8px;
+    right: 8px;
+    transform: none;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  /* Text Properties → full-width bottom sheet */
+  .df-props-panel {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform: none;
+    width: auto;
+    border-radius: 12px 12px 0 0;
+  }
+}


### PR DESCRIPTION
Add the missing viewport meta tag so mobile browsers render at true
device scale instead of laying out at desktop width and shrinking.

Make the floating UI responsive: move positioning out of inline styles
(which outrank CSS) into namespaced classes in global.css, then add a
max-width:640px media query. On small screens the corner menus shrink to
the edges, the tool toolbar becomes a full-width bottom bar, and the Text
Properties panel becomes a bottom sheet, so nothing overlaps the canvas.

https://claude.ai/code/session_01Mdi2JE36fivUkUknw79guq