### PR TITLE
Rename ArtboardDocument to DotforgeDocument and standardize naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # dotforge-web
 
-DotForge - frontend
+Dotforge - frontend

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/cloudflare": "^14.0.1",
         "@astrojs/preact": "^6.0.0",
-        "@dotforge/core": "^0.8.0",
+        "@dotforge/core": "^0.9.1",
         "astro": "^7.0.3",
         "lucide-preact": "^1.21.0",
         "preact": "^10.29.2"
@@ -660,9 +660,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -680,9 +677,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -700,9 +694,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -720,9 +711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1066,9 +1054,9 @@
       }
     },
     "node_modules/@dotforge/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@dotforge/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-eecye9vpwoQB1Ydv1UEWMhZVElIiVqWpgiZ7uSsuYE+NP0GJAeUqIWtP7FZqvn4P56ZVTrk5aOoUouvEB/7ECQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@dotforge/core/-/core-0.9.1.tgz",
+      "integrity": "sha512-pyAqjJxE9xM/JVJOji8LVCNVgzz9fW7LP1CbclmRFYah3rKwAU7evc9uXiWCRZu7udnmHdRlRNiI60lFlB9+AA==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^14.0.1",
     "@astrojs/preact": "^6.0.0",
-    "@dotforge/core": "^0.8.0",
+    "@dotforge/core": "^0.9.0",
     "astro": "^7.0.3",
     "lucide-preact": "^1.21.0",
     "preact": "^10.29.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^14.0.1",
     "@astrojs/preact": "^6.0.0",
-    "@dotforge/core": "^0.9.0",
+    "@dotforge/core": "^0.9.1",
     "astro": "^7.0.3",
     "lucide-preact": "^1.21.0",
     "preact": "^10.29.2"

--- a/src/SampleDocument.ts
+++ b/src/SampleDocument.ts
@@ -1,6 +1,6 @@
-import type { ArtboardDocument } from "@dotforge/core";
+import type { DotforgeDocument } from "@dotforge/core";
 
-export default function SampleArtboard(): ArtboardDocument {
+export default function SampleDocument(): DotforgeDocument {
   return {
     width: 100,
     height: 150,
@@ -9,7 +9,7 @@ export default function SampleArtboard(): ArtboardDocument {
         type: "text",
         x: 5,
         y: 10,
-        text: "Hello DotForge",
+        text: "Hello Dotforge",
         fontSize: 3,
       },
     ],

--- a/src/components/ArtboardRenderer.tsx
+++ b/src/components/ArtboardRenderer.tsx
@@ -1,11 +1,11 @@
-import type { TextElement } from "@dotforge/core";
+import type { DotforgeDocument, TextElement } from "@dotforge/core";
 import { useRef } from "preact/hooks";
 import type { Tool } from "./layout/ShapesToolbar";
 
 const DRAG_THRESHOLD_PX = 3;
 
 export default function ArtboardRenderer({
-  artboard,
+  doc,
   selected,
   onSelect,
   onResize,
@@ -13,7 +13,7 @@ export default function ArtboardRenderer({
   onAddTextElement,
   activeTool,
 }: {
-  artboard: import("@dotforge/core").ArtboardDocument;
+  doc: DotforgeDocument;
   selected: TextElement | null;
   onSelect: (el: TextElement | null) => void;
   revision: number;
@@ -30,15 +30,15 @@ export default function ArtboardRenderer({
     if (!paper) return px;
     const rect = paper.getBoundingClientRect();
     if (rect.width === 0) return px;
-    return (px / rect.width) * artboard.width;
+    return (px / rect.width) * doc.width;
   }
 
   function clientToMm(clientX: number, clientY: number) {
     const paper = paperRef.current;
     if (!paper) return { x: 0, y: 0 };
     const rect = paper.getBoundingClientRect();
-    const scaleX = rect.width === 0 ? 1 : artboard.width / rect.width;
-    const scaleY = rect.height === 0 ? 1 : artboard.height / rect.height;
+    const scaleX = rect.width === 0 ? 1 : doc.width / rect.width;
+    const scaleY = rect.height === 0 ? 1 : doc.height / rect.height;
     return {
       x: (clientX - rect.left) * scaleX,
       y: (clientY - rect.top) * scaleY,
@@ -69,8 +69,8 @@ export default function ArtboardRenderer({
       }
       const nextX = startX + pxToMm(dx);
       const nextY = startY + pxToMm(dy);
-      const clampedX = Math.max(0, Math.min(artboard.width, nextX));
-      const clampedY = Math.max(0, Math.min(artboard.height, nextY));
+      const clampedX = Math.max(0, Math.min(doc.width, nextX));
+      const clampedY = Math.max(0, Math.min(doc.height, nextY));
       onMoveElement(el, clampedX, clampedY);
     };
 
@@ -132,8 +132,8 @@ export default function ArtboardRenderer({
             background: "white",
             border: "2px solid var(--panel-border)",
             borderRadius: "6px",
-            width: `${artboard.width}mm`,
-            height: `${artboard.height}mm`,
+            width: `${doc.width}mm`,
+            height: `${doc.height}mm`,
             overflow: "hidden",
             display: "flex",
             alignItems: "flex-start",
@@ -143,7 +143,7 @@ export default function ArtboardRenderer({
           }}
           onClick={handlePaperClick}
         >
-          {artboard.elements.map((el) => (
+          {doc.elements.map((el) => (
             // biome-ignore lint/a11y/useKeyWithClickEvents: Artboard elements use pointer-based drag/click interaction for visual editing.
             // biome-ignore lint/a11y/noStaticElementInteractions: Artboard elements use pointer-based drag/click interaction for visual editing.
             <div
@@ -195,11 +195,11 @@ export default function ArtboardRenderer({
               <input
                 type="number"
                 min={1}
-                value={artboard.width}
+                value={doc.width}
                 onInput={(e) => {
                   const v = Number((e.target as HTMLInputElement).value);
                   if (Number.isFinite(v) && v > 0) {
-                    onResize(v, artboard.height);
+                    onResize(v, doc.height);
                   }
                 }}
                 style={{ width: "60px" }}
@@ -213,11 +213,11 @@ export default function ArtboardRenderer({
               <input
                 type="number"
                 min={1}
-                value={artboard.height}
+                value={doc.height}
                 onInput={(e) => {
                   const v = Number((e.target as HTMLInputElement).value);
                   if (Number.isFinite(v) && v > 0) {
-                    onResize(artboard.width, v);
+                    onResize(doc.width, v);
                   }
                 }}
                 style={{ width: "60px" }}

--- a/src/components/DocumentEditor.tsx
+++ b/src/components/DocumentEditor.tsx
@@ -1,17 +1,17 @@
-import type { ArtboardDocument, TextElement } from "@dotforge/core";
+import type { DotforgeDocument, TextElement } from "@dotforge/core";
 import { useEffect, useState } from "preact/hooks";
 import FileToolbar from "../components/layout/FileToolbar";
 import PropertiesPanel from "../components/layout/PropertiesPanel";
 import ShapesToolbar, { type Tool } from "../components/layout/ShapesToolbar";
-import { downloadArtboard, parseArtboard } from "../lib/dotforge";
+import { downloadDocument, parseDocument } from "../lib/dotforge";
 import ArtboardRenderer from "./ArtboardRenderer";
 
-export default function ArtboardEditor({
-  artboard: initialArtboard,
+export default function DocumentEditor({
+  doc: initialDoc,
 }: {
-  artboard: ArtboardDocument;
+  doc: DotforgeDocument;
 }) {
-  const [artboard, setArtboard] = useState<ArtboardDocument>(initialArtboard);
+  const [doc, setDoc] = useState<DotforgeDocument>(initialDoc);
   const [selected, setSelected] = useState<TextElement | null>(null);
   const [revision, setRevision] = useState(0);
   const [activeTool, setActiveTool] = useState<Tool>("select");
@@ -31,9 +31,9 @@ export default function ArtboardEditor({
   }
 
   function handleDeleteElement(el: TextElement) {
-    const idx = artboard.elements.indexOf(el);
+    const idx = doc.elements.indexOf(el);
     if (idx === -1) return;
-    artboard.elements.splice(idx, 1);
+    doc.elements.splice(idx, 1);
     setSelected((current) => (current === el ? null : current));
     forceUpdate();
   }
@@ -66,25 +66,25 @@ export default function ArtboardEditor({
       text: "Text",
       fontSize: 3,
     };
-    artboard.elements.push(newEl);
+    doc.elements.push(newEl);
     setSelected(newEl);
     setActiveTool("select");
     forceUpdate();
   }
 
   function handleResize(width: number, height: number) {
-    setArtboard((prev) => ({ ...prev, width, height }));
+    setDoc((prev) => ({ ...prev, width, height }));
   }
 
   function handleDownload() {
-    downloadArtboard(artboard);
+    downloadDocument(doc);
   }
 
   async function handleUploadFile(file: File) {
     try {
       const text = await file.text();
-      const loaded = parseArtboard(text);
-      setArtboard(loaded);
+      const loaded = parseDocument(text);
+      setDoc(loaded);
       setSelected(null);
       setActiveTool("select");
       forceUpdate();
@@ -104,7 +104,7 @@ export default function ArtboardEditor({
       }}
     >
       <ArtboardRenderer
-        artboard={artboard}
+        doc={doc}
         selected={selected}
         onSelect={handleSelect}
         revision={revision}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const themeColorsJson = JSON.stringify(themeColors);
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content={themeColors.light} />
-        <title>{pageTitle || "DotForge"}</title>
+        <title>{pageTitle || "Dotforge"}</title>
         <script is:inline define:vars={{ themeColorsJson }}>
             (function() {
                 var themeColors = JSON.parse(themeColorsJson);

--- a/src/lib/dotforge.ts
+++ b/src/lib/dotforge.ts
@@ -1,13 +1,13 @@
-import type { ArtboardDocument } from "@dotforge/core";
+import type { DotforgeDocument } from "@dotforge/core";
 
 export const DOTFORGE_FILE_EXTENSION = ".dotforge";
 export const DOTFORGE_MIME_TYPE = "application/json";
 
-export function serializeArtboard(artboard: ArtboardDocument): string {
-  return JSON.stringify(artboard, null, 2);
+export function serializeDocument(doc: DotforgeDocument): string {
+  return JSON.stringify(doc, null, 2);
 }
 
-export function parseArtboard(text: string): ArtboardDocument {
+export function parseDocument(text: string): DotforgeDocument {
   const parsed = JSON.parse(text);
   if (
     !parsed ||
@@ -18,14 +18,14 @@ export function parseArtboard(text: string): ArtboardDocument {
   ) {
     throw new Error("Not a valid .dotforge file");
   }
-  return parsed as ArtboardDocument;
+  return parsed as DotforgeDocument;
 }
 
-export function downloadArtboard(
-  artboard: ArtboardDocument,
-  filename = `artboard${DOTFORGE_FILE_EXTENSION}`,
+export function downloadDocument(
+  doc: DotforgeDocument,
+  filename = `untitled${DOTFORGE_FILE_EXTENSION}`,
 ) {
-  const blob = new Blob([serializeArtboard(artboard)], {
+  const blob = new Blob([serializeDocument(doc)], {
     type: DOTFORGE_MIME_TYPE,
   });
   const url = URL.createObjectURL(blob);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,9 @@
 ---
-import ArtboardEditor from "@/components/ArtboardEditor.tsx";
+import DocumentEditor from "@/components/DocumentEditor.tsx";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import SampleArtboard from "@/SampleArtboard";
+import SampleDocument from "@/SampleDocument";
 ---
 
-<BaseLayout pageTitle="DotForge - Editor" activeModule="artboard">
-  <ArtboardEditor artboard={SampleArtboard()} client:load />
+<BaseLayout pageTitle="Dotforge - Editor" activeModule="artboard">
+  <DocumentEditor doc={SampleDocument()} client:load />
 </BaseLayout>

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -10,8 +10,10 @@ test("homepage loads successfully", async ({ page }) => {
 test("document editor is present", async ({ page }) => {
   await page.goto("/");
 
-  // Wait for the document editor component to be visible
-  // The DocumentEditor component should be present on the page
-  const documentEditor = page.locator("body");
-  await expect(documentEditor).toBeVisible();
+  // The file toolbar and the rendered sample document prove the
+  // DocumentEditor component actually mounted
+  await expect(
+    page.getByRole("button", { name: "Download .dotforge" }),
+  ).toBeVisible();
+  await expect(page.getByText("Hello Dotforge")).toBeVisible();
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -15,7 +15,5 @@ test("document editor is present", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: "Download .dotforge" }),
   ).toBeVisible();
-  await expect(
-    page.getByText("Hello Dotforge", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByText("Hello Dotforge", { exact: true })).toBeVisible();
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -4,14 +4,14 @@ test("homepage loads successfully", async ({ page }) => {
   await page.goto("/");
 
   // Check that the page title is correct
-  await expect(page).toHaveTitle(/DotForge - Editor/);
+  await expect(page).toHaveTitle(/Dotforge - Editor/);
 });
 
-test("artboard editor is present", async ({ page }) => {
+test("document editor is present", async ({ page }) => {
   await page.goto("/");
 
-  // Wait for the artboard editor component to be visible
-  // The ArtboardEditor component should be present on the page
-  const artboardEditor = page.locator("body");
-  await expect(artboardEditor).toBeVisible();
+  // Wait for the document editor component to be visible
+  // The DocumentEditor component should be present on the page
+  const documentEditor = page.locator("body");
+  await expect(documentEditor).toBeVisible();
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -15,5 +15,7 @@ test("document editor is present", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: "Download .dotforge" }),
   ).toBeVisible();
-  await expect(page.getByText("Hello Dotforge")).toBeVisible();
+  await expect(
+    page.getByText("Hello Dotforge", { exact: true }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary

The central entity is a **document** that happens to be displayed on an artboard, not an "artboard document". Data-layer names now say "document"; "artboard" survives only where it means the canvas view.

**Document (data layer):**
- `serializeArtboard`/`parseArtboard`/`downloadArtboard` → `serializeDocument`/`parseDocument`/`downloadDocument`
- `SampleArtboard.ts` → `SampleDocument.ts`
- `ArtboardEditor` → `DocumentEditor`
- Props/state `artboard` → `doc` (not `document`, which would shadow the DOM global — same reason the type keeps the app prefix)
- Default download filename `artboard.dotforge` → `untitled.dotforge`
- `@dotforge/core` bumped to `^0.9.1`, which exports the renamed `DotforgeDocument`

**Artboard (view layer, unchanged):** `ArtboardRenderer`, the "Artboard" module tab, `activeModule="artboard"`.

**Brand casing** normalized to "Dotforge" (page titles, "Hello Dotforge" sample text, README).

**Test hardening** (from review): the homepage spec now asserts the editor toolbar and rendered sample document (exact text match) instead of just `<body>` visibility.

## Merge order

Part 3 of a 3-repo rename — meta and core are merged and `@dotforge/core@0.9.1` is published to npm (0.9.0 hit a publishing issue and was skipped). The lockfile resolves 0.9.1, so CI runs against the real published package.

## Verification

`npm run type-check`, `npx biome check src tests`, `astro build`, and both Playwright homepage specs pass against the published 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jdx9kF7Tz9eWCiYtTx3va3